### PR TITLE
Update discovery.js

### DIFF
--- a/lib/discovery.js
+++ b/lib/discovery.js
@@ -38,13 +38,11 @@ function onDiscovery(peripheral) {
   packetsReceived++;
 
   var id = peripheral.address;
-  if (id in config.known_devices)
-    id = config.known_devices[id];
   var entered = !inRange[id];
 
   if (entered) {
     inRange[id] = {
-      id : id,
+      id : id in config.known_devices ? config.known_devices[id] : id,
       address : peripheral.address,
       peripheral: peripheral,
       name : "?",


### PR DESCRIPTION
I guess you shouldn't change id to the ```known_devices``` name, because all following checks for ```discovery.inRange[MAC]``` will return undefined (aka not in range)