### PR TITLE
Fix install instructions for Raspbian

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,11 @@ Setting up
 Assuming a blank Pi:
 
 ```
-# Get node, npm, node-red, etc
-sudo apt-get install npm mosquitto mosquitto-clients nodered bluetooth bluez libbluetooth-dev libudev-dev
+# Install a modern version of nodejs
+curl -sL https://deb.nodesource.com/setup_7.x |sudo -E bash -
+sudo apt-get install nodejs
+# Get dependencies
+sudo apt-get install mosquitto mosquitto-clients nodered bluetooth bluez libbluetooth-dev libudev-dev
 # Install node-red service
 sudo systemctl enable nodered.service
 # Start nodered manually this one time (this creates ~/.node-red)

--- a/README.md
+++ b/README.md
@@ -10,22 +10,18 @@ Setting up
 Assuming a blank Pi:
 
 ```
-# Install a modern version of nodejs
-curl -sL https://deb.nodesource.com/setup_7.x |sudo -E bash -
-sudo apt-get install nodejs
+# Install a modern version of nodejs and nodered
+sudo apt-get install build-essential python-rpi.gpio
+bash <(curl -sL https://raw.githubusercontent.com/node-red/raspbian-deb-package/master/resources/update-nodejs-and-nodered)
 # Get dependencies
-sudo apt-get install mosquitto mosquitto-clients nodered bluetooth bluez libbluetooth-dev libudev-dev
-# Install node-red service
+sudo apt-get install mosquitto mosquitto-clients bluetooth bluez libbluetooth-dev libudev-dev
+
+# Auto start node-red
 sudo systemctl enable nodered.service
 # Start nodered manually this one time (this creates ~/.node-red)
 sudo systemctl start nodered.service
 # Install the node-red UI
 cd ~/.node-red && npm install node-red-contrib-ui
-
-# As it comes, NPM on the Pi is broken
-# and doesn't like installing native libs. Update NPM
-sudo npm -g install npm node-gyp
-
 # Now get this repository
 cd ~/
 git clone https://github.com/espruino/EspruinoHub

--- a/README.md
+++ b/README.md
@@ -11,17 +11,20 @@ Assuming a blank Pi:
 
 ```
 # Get node, npm, node-red, etc
-sudo apt-get install node npm mosquitto mosquitto-clients nodered bluetooth bluez libbluetooth-dev libudev-dev
+sudo apt-get install npm mosquitto mosquitto-clients nodered bluetooth bluez libbluetooth-dev libudev-dev
 # Install node-red service
 sudo systemctl enable nodered.service
+# Start nodered manually this one time (this creates ~/.node-red)
+sudo systemctl start nodered.service
 # Install the node-red UI
-cd .node-red && sudo npm install node-red-contrib-ui
+cd ~/.node-red && npm install node-red-contrib-ui
 
 # As it comes, NPM on the Pi is broken
 # and doesn't like installing native libs. Update NPM
 sudo npm -g install npm node-gyp
 
 # Now get this repository
+cd ~/
 git clone https://github.com/espruino/EspruinoHub
 # Install its' requirements
 cd EspruinoHub

--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
   "dependencies": {
     "bleno": "^0.4.1",
     "mqtt": "^2.0.1",
-    "noble": "^1.7.0",
-    "bluetooth-hci-socket": "^0.5"
+    "noble": "^1.7.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "dependencies": {
     "bleno": "^0.4.1",
     "mqtt": "^2.0.1",
-    "noble": "^1.7.0"
+    "noble": "^1.7.0",
+    "bluetooth-hci-socket": "^0.5"
   }
 }


### PR DESCRIPTION
This adds a missing dependency (to `bluetooth-hci-socket`). Unfortunately this dependency does not seem to build with the Raspbian provided nodejs and we have to switch to a more modern version. This in turns means that we need to install nodered manually.

This is documented by nodered here: http://nodered.org/docs/hardware/raspberrypi.html#manual-install