### PR TITLE
`manufacturerData` addition to advertisements

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,8 @@ via advertising.
 Useful MQTT parts are:
 
 * `/ble/presence/DEVICE` - 1 or 0 depending on whether device has been seen or not
-* `/ble/advertise/DEVICE` - JSON for device's broadcast name and rssi
+* `/ble/advertise/DEVICE` - JSON for device's broadcast name, rssi and manufacturer-specific data
+* `/ble/advertise/DEVICE/manufacturer/COMPANY/FORMAT` - Manufacturer-specific data in `hex` or `base64` format
 * `/ble/advertise/DEVICE/rssi` - Device signal strength
 * `/ble/advertise/DEVICE/SERVICE` - Raw service data (as JSON)
 * `/ble/advertise/DEVICE/PRETTY` or `/ble/PRETTY/DEVICE` - Decoded service data. `temp` is the obvious one

--- a/README.md
+++ b/README.md
@@ -16,11 +16,11 @@ bash <(curl -sL https://raw.githubusercontent.com/node-red/raspbian-deb-package/
 # Get dependencies
 sudo apt-get install mosquitto mosquitto-clients bluetooth bluez libbluetooth-dev libudev-dev
 
-# Auto start node-red
+# Auto start Node-RED
 sudo systemctl enable nodered.service
 # Start nodered manually this one time (this creates ~/.node-red)
 sudo systemctl start nodered.service
-# Install the node-red UI
+# Install the Node-RED UI
 cd ~/.node-red && npm install node-red-contrib-ui
 # Now get this repository
 cd ~/
@@ -41,7 +41,7 @@ Usage
 
 Run with `start.sh` (ideally you'd set this to auto-start - see below)
 
-You can then access Node-red using `http://localhost:1880`
+You can then access Node-RED using `http://localhost:1880`
 
 Once you add UI elements and click `Deploy` they'll be visible at `http://localhost:1880/ui`
 
@@ -53,10 +53,15 @@ Useful MQTT parts are:
 
 * `/ble/presence/DEVICE` - 1 or 0 depending on whether device has been seen or not
 * `/ble/advertise/DEVICE` - JSON for device's broadcast name, rssi and manufacturer-specific data
-* `/ble/advertise/DEVICE/manufacturer/COMPANY/FORMAT` - Manufacturer-specific data in `hex` or `base64` format
+* `/ble/advertise/DEVICE/manufacturer/COMPANY` - Manufacturer-specific data (without leading company code)
 * `/ble/advertise/DEVICE/rssi` - Device signal strength
 * `/ble/advertise/DEVICE/SERVICE` - Raw service data (as JSON)
 * `/ble/advertise/DEVICE/PRETTY` or `/ble/PRETTY/DEVICE` - Decoded service data. `temp` is the obvious one
+
+To decode the hex-encoded manufacturer-specific data, try:
+```
+var data = Buffer.from(msg.payload.manufacturerData, 'hex');
+```
 
 
 Auto Start

--- a/lib/discovery.js
+++ b/lib/discovery.js
@@ -64,6 +64,11 @@ function onDiscovery(peripheral) {
   inRange[addr].lastSeen = Date.now();
   inRange[addr].rssi = peripheral.rssi;
 
+  if (peripheral.advertisement.manufacturerData) {
+    mqttData.manufacturerData = peripheral.advertisement.manufacturerData;
+    inRange[addr].manufacturerData = peripheral.advertisement.manufacturerData;
+  }
+
   mqtt.send("/ble/advertise/"+id, JSON.stringify(mqttData));
   mqtt.send("/ble/advertise/"+id+"/rssi", JSON.stringify(peripheral.rssi));
 

--- a/lib/discovery.js
+++ b/lib/discovery.js
@@ -77,8 +77,8 @@ function onDiscovery(peripheral) {
     var rest = mdata.slice(2);
 
     // Split out the manufacturer specific data in two forms
-    mqtt.send("/ble/advertise/"+id+"/manufacturer/"+manu+"/hex", rest.toString('hex'));
-    mqtt.send("/ble/advertise/"+id+"/manufacturer/"+manu+"/base64", rest.toString('base64'));
+    mqtt.send("/ble/advertise/"+id+"/manufacturer/"+manu+"/hex", JSON.stringify(rest.toString('hex')));
+    mqtt.send("/ble/advertise/"+id+"/manufacturer/"+manu+"/base64", JSON.stringify(rest.toString('base64')));
   }
   else {
     // No manufacturer specific data

--- a/lib/discovery.js
+++ b/lib/discovery.js
@@ -65,13 +65,26 @@ function onDiscovery(peripheral) {
   inRange[addr].rssi = peripheral.rssi;
 
   if (peripheral.advertisement.manufacturerData) {
-    // Convert from Buffer to hex.  'base64' would be more efficient, but
-    // 'hex' is easier to decode without libraries.
-    mqttData.manufacturerData = peripheral.advertisement.manufacturerData.toString('hex');
-    inRange[addr].manufacturerData = mqttData.manufacturerData;
+    var mdata = peripheral.advertisement.manufacturerData;
+
+    // Include the entire raw string, incl. manufacturer, as hex
+    mqttData.manufacturerData = mdata.toString('hex');
+    mqtt.send("/ble/advertise/"+id, JSON.stringify(mqttData));
+
+    // First two bytes is the manufacturer code
+    // re: https://www.bluetooth.com/specifications/assigned-numbers/company-identifiers
+    var manu = mdata.slice(0,2).swap16().toString('hex');
+    var rest = mdata.slice(2);
+
+    // Split out the manufacturer specific data in two forms
+    mqtt.send("/ble/advertise/"+id+"/manufacturer/"+manu+"/hex", rest.toString('hex'));
+    mqtt.send("/ble/advertise/"+id+"/manufacturer/"+manu+"/base64", rest.toString('base64'));
+  }
+  else {
+    // No manufacturer specific data
+    mqtt.send("/ble/advertise/"+id, JSON.stringify(mqttData));
   }
 
-  mqtt.send("/ble/advertise/"+id, JSON.stringify(mqttData));
   mqtt.send("/ble/advertise/"+id+"/rssi", JSON.stringify(peripheral.rssi));
 
   peripheral.advertisement.serviceData.forEach(function(d) {

--- a/lib/discovery.js
+++ b/lib/discovery.js
@@ -65,20 +65,19 @@ function onDiscovery(peripheral) {
   inRange[addr].rssi = peripheral.rssi;
 
   if (peripheral.advertisement.manufacturerData) {
-    var mdata = peripheral.advertisement.manufacturerData;
+    var mdata = peripheral.advertisement.manufacturerData.toString('hex');
 
     // Include the entire raw string, incl. manufacturer, as hex
-    mqttData.manufacturerData = mdata.toString('hex');
+    mqttData.manufacturerData = mdata;
     mqtt.send("/ble/advertise/"+id, JSON.stringify(mqttData));
 
-    // First two bytes is the manufacturer code
+    // First two bytes is the manufacturer code (little-endian)
     // re: https://www.bluetooth.com/specifications/assigned-numbers/company-identifiers
-    var manu = mdata.slice(0,2).swap16().toString('hex');
-    var rest = mdata.slice(2);
+    var manu = mdata.slice(2,4) + mdata.slice(0,2);
+    var rest = mdata.slice(4);
 
-    // Split out the manufacturer specific data in two forms
-    mqtt.send("/ble/advertise/"+id+"/manufacturer/"+manu+"/hex", JSON.stringify(rest.toString('hex')));
-    mqtt.send("/ble/advertise/"+id+"/manufacturer/"+manu+"/base64", JSON.stringify(rest.toString('base64')));
+    // Split out the manufacturer specific data
+    mqtt.send("/ble/advertise/"+id+"/manufacturer/"+manu, JSON.stringify(rest));
   }
   else {
     // No manufacturer specific data

--- a/lib/discovery.js
+++ b/lib/discovery.js
@@ -65,8 +65,10 @@ function onDiscovery(peripheral) {
   inRange[addr].rssi = peripheral.rssi;
 
   if (peripheral.advertisement.manufacturerData) {
-    mqttData.manufacturerData = peripheral.advertisement.manufacturerData;
-    inRange[addr].manufacturerData = peripheral.advertisement.manufacturerData;
+    // Convert from Buffer to hex.  'base64' would be more efficient, but
+    // 'hex' is easier to decode without libraries.
+    mqttData.manufacturerData = peripheral.advertisement.manufacturerData.toString('hex');
+    inRange[addr].manufacturerData = mqttData.manufacturerData;
   }
 
   mqtt.send("/ble/advertise/"+id, JSON.stringify(mqttData));


### PR DESCRIPTION
I've found a few devices advertise sensor data in the manufacturer-specific data field.  For example, the new version of the default firmware for RuuviTag (weather station) switches to a [high-precision, higher frequency](https://github.com/ruuvi/ruuvi-sensor-protocols#protocol-specification-data-format-3) mode when the "B" button is pressed, switching from the Eddystone-structured output to the Manufacturer Specific Data field.

This commit adds that raw data to the `/ble/advertise/...` message, encoded as hex.

It also splits out the 16-bit manufacturer code (eg. `0x0499` for Ruuvi) and dumps the rest of the data out in both hex and Base64 format:

eg.:
```
/ble/presence/ruuvi_outside 1
/ble/advertise/ruuvi_outside {"rssi":-86,"manufacturerData":"990403550d16cf9c0399014800610b3b00000000"}
/ble/advertise/ruuvi_outside/manufacturer/0499/hex "03550d16cf9c0399014800610b3b00000000"
/ble/advertise/ruuvi_outside/manufacturer/0499/base64 "A1UNFs+cA5kBSABhCzsAAAAA"
/ble/advertise/ruuvi_outside/rssi -86
```

Admittedly, this might be overkill.  Hex is easier for simple JS, but Base64 is more efficient. For Node-RED, Base64 is probably easier to process.

I have no objection to it being slimmed down if this is too redundant.
