### PR TITLE
Disable status display when running without console, eg. `systemd`

### DIFF
--- a/lib/status.js
+++ b/lib/status.js
@@ -57,6 +57,8 @@ var logHistory = [];
  // -----------------------------------------
 
 exports.init = function() {
+  if (undefined === process.stdout.getWindowSize)
+    return;
   console._log = console.log;
   /** Replace existing console.log with something that'll let us
   report status alongside evrything else */


### PR DESCRIPTION
When running under `systemd`, it's a dumb tty (at least to some extent) so no fancy formatting.  Heck, why not just disable the status?  It'll just fill up the journals anyway.

I forgot to commit this change in the previous PR.