### PR TITLE
Support serialized buffers

### DIFF
--- a/lib/connect.js
+++ b/lib/connect.js
@@ -29,7 +29,7 @@ exports.write = function(device, service, characteristic, data) {
     device : device,
     service : util.uuid2noble(service),
     characteristic : util.uuid2noble(characteristic),
-    data : data
+    data : util.obj2buf(data)
   });
   if (!inProgress)
     serviceQueue();
@@ -51,8 +51,8 @@ exports.read = function(device, service, characteristic, callback) {
 /* Recursive write to characteristic */
 function writeToCharacteristic(characteristic, message) { // added function to write longer strings
   if (message.length) {
-    var data = util.obj2buf(message.substr(0, 20));
-    message = message.substr(20);
+    var data = message.slice(0, 20);
+    message = message.slice(20);
     characteristic.write(data, false, function() {
       log("wrote data: " + data.length + " bytes");
       writeToCharacteristic(characteristic, message);

--- a/lib/util.js
+++ b/lib/util.js
@@ -22,6 +22,8 @@ exports.str2buf = function(str) {
 };
 
 exports.obj2buf = function(o) {
+  if ((typeof o)=="object" && o.type=="Buffer")
+    return new Buffer(o.data);
   if ((typeof o)=="number" ||
       (typeof o)=="boolean") {
     var buf = new Buffer(1); 


### PR DESCRIPTION
I'm not sure if I might have just missed something, but it looked like binary support was a little tricky, so I thought that it would be nice to make it easier by leveraging how node serializes buffers.  

```
> JSON.stringify(Buffer.from([1,99,170,85,0,0,0]))
'{"type":"Buffer","data":[1,99,170,85,0,0,0]}'
```
> in this example, i'm using blink1's USB protocol, but over BLE

The idea is, with this, you can drop either strings, or JSON onto the mqtt topic, and if the JSON was a serialized buffer, it'll be reversed back into a buffer.  Since the data is ultimately sent as a buffer, it seemed like this wouldn't be a huge leap.

Let me know what you think, if you have any test cases to make sure I'm not breaking existing functionality, or if this is just not the direction the project is going.