### PR TITLE
Device filtering

### DIFF
--- a/config.json
+++ b/config.json
@@ -5,6 +5,9 @@
     "fc:a6:c6:04:db:79" : "hall_down",
     "cf:71:de:4d:f8:48" : "hall_up"
   },
+  "// Set this to true to only publish MQTT messages for known devices":0,
+  "only_known_devices": false,
+
   "// We can add our own custom advertising UUIDs here with names to help decode them":0, 
   "advertised_services" : {
     "ffff" : {

--- a/lib/config.js
+++ b/lib/config.js
@@ -25,6 +25,9 @@ exports.http_whitelist = [];
 /** list of services that can be decoded */
 exports.advertised_services = {};
 
+/** switch indicating whether discovery should only accept known devices */
+exports.only_known_devices = false;
+
 
 function log(x) {
   console.log("<Config> "+x);
@@ -49,6 +52,8 @@ exports.init = function() {
         exports.known_devices[k.toString().toLowerCase()] = json.known_devices[k];
       });
     }
+    if (json.only_known_devices)
+      exports.only_known_devices = json.only_known_devices;
     exports.mqtt_host = json.mqtt_host ? json.mqtt_host : 'mqtt://localhost';
     exports.mqtt_options = json.mqtt_options ? json.mqtt_options : {};
     if (json.http_whitelist)

--- a/lib/discovery.js
+++ b/lib/discovery.js
@@ -41,12 +41,15 @@ function onStateChange(state) {
 
 // ----------------------------------------------------------------------
 function onDiscovery(peripheral) {
-  packetsReceived++;
-
   var addr = peripheral.address;
   var id = addr;
-  if (id in config.known_devices)
+  if (id in config.known_devices) {
     id = config.known_devices[id];
+  } else {
+    if (config.only_known_devices)
+      return;
+  }
+  packetsReceived++;
   var entered = !inRange[addr];
 
   if (entered) {


### PR DESCRIPTION
Adds configuration option for discarding packets from devices other than the ones listed in `known_devices`.

Use case:
I had EspruinoHub connected to hbmqtt broker built into Home Assistant on a Raspberry Pi 3, and the onslaught of advertise packets from BLE devices in my vicinity has caused significantly higher CPU usage (30-50%) when "idle".
This option lets the user choose what gets to the broker.