### PR TITLE
Configurable BLE timeout

### DIFF
--- a/config.json
+++ b/config.json
@@ -5,6 +5,10 @@
     "fc:a6:c6:04:db:79" : "hall_down",
     "cf:71:de:4d:f8:48" : "hall_up"
   },
+  "// How many seconds to wait for a packet before considering BLE connection broken and exiting":0,
+  "// Higher values are useful with slowly advertising sensors":0,
+  "ble_timeout": 10,
+
   "// We can add our own custom advertising UUIDs here with names to help decode them":0, 
   "advertised_services" : {
     "ffff" : {

--- a/lib/config.js
+++ b/lib/config.js
@@ -25,6 +25,9 @@ exports.http_whitelist = [];
 /** list of services that can be decoded */
 exports.advertised_services = {};
 
+/** how many seconds to wait for a packet before considering BLE 
+connection broken and exiting */
+exports.ble_timeout = 10;
 
 function log(x) {
   console.log("<Config> "+x);
@@ -49,6 +52,8 @@ exports.init = function() {
         exports.known_devices[k.toString().toLowerCase()] = json.known_devices[k];
       });
     }
+    if (json.ble_timeout)
+      exports.ble_timeout = json.ble_timeout;
     exports.mqtt_host = json.mqtt_host ? json.mqtt_host : 'mqtt://localhost';
     exports.mqtt_options = json.mqtt_options ? json.mqtt_options : {};
     if (json.http_whitelist)

--- a/lib/discovery.js
+++ b/lib/discovery.js
@@ -132,7 +132,7 @@ function checkIfBroken() {
   if (isScanning) {
     // If no packets for 10 seconds, restart
     if (packetsReceived==0 && lastPacketsReceived==0) {
-      log("BLE broken? No advertising packets in 10 seconds - restarting!");
+      log("BLE broken? No advertising packets in "+ config.ble_timeout +" seconds - restarting!");
       process.exit(1);
    } 
   } else {
@@ -152,7 +152,7 @@ exports.init = function() {
   });
   noble.on('scanStop', function() { isScanning=false; log("Scanning stopped.");});
   setInterval(checkForPresence, 1000);
-  setInterval(checkIfBroken, 5000);
+  setInterval(checkIfBroken, config.ble_timeout * 1000);
 };
 
 exports.inRange = inRange;


### PR DESCRIPTION
This makes the previously hardcoded BLE timeout configurable.

Use case:
I'm using my Puck.js as a low-frequency (each 5-10 seconds) sensor, reporting values through advertise packets. With the hardcoded setting, EspruinoHub would restart a lot. 