### PR TITLE
added topic /ble/read/DEVICE for scanning services and characteristics

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ You can also connect to a device:
 
 * `/ble/write/DEVICE/SERVICE/CHARACTERISTIC` connects and writes to the charactertistic
 * `/ble/read/DEVICE/SERVICE/CHARACTERISTIC` connects and reads from the charactertistic
+* `/ble/read/DEVICE` connects and reads an array of services and charactertistics
 * `/ble/notify/DEVICE/SERVICE/CHARACTERISTIC` connects and starts notifications on the characteristic, which
 send data back on `/ble/data/DEVICE/SERVICE/CHARACTERISTIC`
 * `/ble/ping/DEVICE` connects, or maintains a connection to the device, and sends `/ble/pong/DEVICE` on success

--- a/lib/connect.js
+++ b/lib/connect.js
@@ -36,7 +36,7 @@ function Connection(device, callback) {
 
   log(connection.name+": Connecting...");
   device.connect(function (error) {
-    if (error) {      
+    if (error) {
       log(connection.name+": Error Connecting: "+error.toString());
       connection.device = undefined;
       connection.close();
@@ -44,7 +44,7 @@ function Connection(device, callback) {
     } else {
       log("Connected.");
       callback(null, connection);
-    }    
+    }
   });
 }
 Connection.prototype.getCharacteristic = function(serviceUUID, characteristicUUID, callback) {
@@ -61,8 +61,8 @@ Connection.prototype.getCharacteristic = function(serviceUUID, characteristicUUI
         };
         log(connection.name+": found characteristic: " + matchedCharacteristic.uuid);
         callback(null, matchedCharacteristic);
-      } else {          
-        callback("Characteristic "+characteristicUUID+" not found");        
+      } else {
+        callback("Characteristic "+characteristicUUID+" not found");
       }
     });
   }
@@ -74,7 +74,7 @@ Connection.prototype.getCharacteristic = function(serviceUUID, characteristicUUI
 
   log(connection.name+": Getting Service...");
   var timeout = setTimeout(function() {
-    timeout = undefined;    
+    timeout = undefined;
     log(connection.name+": Timed out getting services.");
     callback("Timed out getting services.");
   }, 4000);
@@ -91,21 +91,75 @@ Connection.prototype.getCharacteristic = function(serviceUUID, characteristicUUI
         getCharacteristicFromService(matchedService);
       } else {
         if (timeout) clearTimeout(timeout);
-        callback("Service "+serviceUUID+" not found");        
+        callback("Service "+serviceUUID+" not found");
       }
-    });  
+    });
   }
 }
 
+Connection.prototype.getServices = function(callback) {
+  var connection = this;
 
-Connection.prototype.close = function() { 
+  function handleService(allServices,index){
+    matchedService = allServices[index]
+    log(connection.name+": found service: " + matchedService.uuid, "getting Characteristic....");
+    if (!connection.services[matchedService.uuid])
+      connection.services[matchedService.uuid] = { service : matchedService };
+    matchedService.discoverCharacteristics(null, function(error, characteristics) { // do search for all characteristics
+      if (!error) {
+        if (timeout) clearTimeout(timeout);
+        if (characteristics != undefined && characteristics.length) {
+          characteristics.forEach(function(matchedCharacteristic){
+            connection.services[matchedService.uuid][matchedCharacteristic.uuid] = {
+              characteristic : matchedCharacteristic,
+              notifyCallback : undefined
+            };
+            log(connection.name+": found characteristic: " + matchedCharacteristic.uuid);
+          });
+        }
+        if (index < allServices.length - 1) { // Last service in array?
+          handleService(allServices,index + 1) // Handle next service
+        } else {
+          callback(null,connection.services) // Return connection's services
+        }
+      } else {
+        callback("Failed to discover characteristics")
+      }
+    });
+  }
+
+  // don't look in cache
+
+  log(connection.name+": Getting Services...");
+  var timeout = setTimeout(function() {
+    timeout = undefined;
+    log(connection.name+": Timed out getting services.");
+    callback("Timed out getting services.");
+  }, 4000);
+
+
+  this.device.discoverServices(null, function(error, services) { // do search for all services
+    if(!error) {
+
+      if (services != undefined && services.length) {
+        handleService(services,0)
+      } else {
+        callback(null,{})
+      }
+    } else {
+      callback("Failed to discover services");
+    }
+  });
+}
+
+Connection.prototype.close = function() {
   if (this.device) {
     log(this.name+": Disconnecting.");
-    try { 
-      this.device.disconnect();       
+    try {
+      this.device.disconnect();
       log(this.name+": Disconnected");
-    } catch (e) { 
-      log(this.name+": Disconnect error: "+e); 
+    } catch (e) {
+      log(this.name+": Disconnect error: "+e);
     }
     this.device = undefined;
   }
@@ -124,7 +178,7 @@ Connection.prototype.setUsed = function() {
 // -----------------------------------------------------------------------------
 // -----------------------------------------------------------------------------
 
-// Repeated write to characteristic 
+// Repeated write to characteristic
 function writeToCharacteristic(characteristic, message, callback) { // added function to write longer strings
   if (message.length) {
     var data = message.slice(0, 20);
@@ -176,7 +230,7 @@ function serviceQueue() {
   if (connections.length < MAX_CONNECTIONS) {
     var job = queue.shift();
     discovery.stopScan();
-    setTimeout(job, 1000);  
+    setTimeout(job, 1000);
   }
 }
 
@@ -200,7 +254,7 @@ exports.write = function(device, service, characteristic, data, callback) {
   getConnectedDevice(device, function(err, connection) {
     if (err) return setNotBusy();
 
-    connection.getCharacteristic(util.uuid2noble(service), 
+    connection.getCharacteristic(util.uuid2noble(service),
                                  util.uuid2noble(characteristic),
      function(err,char) {
        if (err) return setNotBusy();;
@@ -222,7 +276,7 @@ exports.read = function(device, service, characteristic, callback) {
   isBusy = true;
   getConnectedDevice(device, function(err, connection) {
     if (err) return;
-    connection.getCharacteristic(util.uuid2noble(service), 
+    connection.getCharacteristic(util.uuid2noble(service),
                                  util.uuid2noble(characteristic),
      function(err,char) {
        if (err) return setNotBusy();
@@ -232,6 +286,48 @@ exports.read = function(device, service, characteristic, callback) {
          setNotBusy();
        });
      });
+  });
+};
+
+/* Read services from the given device */
+exports.readServices = function(device, callback) {
+  if (isBusy) {
+    queue.push(function() { exports.readServices(device,callback); });
+    return;
+  }
+  isBusy = true;
+  getConnectedDevice(device, function(err, connection) {
+    if (err) return;
+    connection.getServices(function(err,services) {
+     if (err) return setNotBusy();
+     /* Extract UUIDs from the connection's services object.
+        Output array format:
+        [
+          {
+            uuid:serviceUuid,
+            characteristics: [
+              {
+                uuid:characteristicUuid
+              }
+            ]
+          }
+        ]
+     */
+     var output = []
+     for (service in services) {
+       var item = {
+         uuid:service,
+         characteristics:[]
+       }
+       for (key in services[service]) {
+         if(key !== 'service') item.characteristics.push({uuid:key})
+       }
+       output.push(item)
+     }
+     // Stringifies array before sending
+     callback(JSON.stringify(output))
+     setNotBusy();
+    });
   });
 };
 
@@ -246,17 +342,17 @@ exports.notify = function(device, service, characteristic, callback) {
     if (err) return setNotBusy();
     var serviceUUID = util.uuid2noble(service);
     var characteristicUUID = util.uuid2noble(characteristic);
-    connection.getCharacteristic(serviceUUID,characteristicUUID, 
+    connection.getCharacteristic(serviceUUID,characteristicUUID,
      function(err,char) {
        if (err) return setNotBusy();
        if (connection.services[serviceUUID][characteristicUUID].notifyCallback) {
          connection.services[serviceUUID][characteristicUUID].notifyCallback = callback;
          return setNotBusy(); // notifications were already set up
-       }       
+       }
        char.on('data', function (data) {
          //log(connection.name+": notification on "+data.toString());
          //new Uint8Array(data).buffer
-         if (connection.services[serviceUUID][characteristicUUID].notifyCallback)            
+         if (connection.services[serviceUUID][characteristicUUID].notifyCallback)
            connection.services[serviceUUID][characteristicUUID].notifyCallback(data.toString());
        });
        char.subscribe(function() {
@@ -276,7 +372,7 @@ exports.ping = function(device, callback) {
   }
   isBusy = true;
   getConnectedDevice(device, function(err, connection) {
-    if (err) return setNotBusy(); 
+    if (err) return setNotBusy();
     if (callback) callback(null);
     setNotBusy();
   });
@@ -296,5 +392,5 @@ setInterval(function() {
       connection.close();
       i--; // connection automatically removes itself from list
     }
-  } 
+  }
 }, 1000);

--- a/lib/mqttclient.js
+++ b/lib/mqttclient.js
@@ -84,12 +84,20 @@ client.on('message', function (topic, message) {
     if (path[1]=="read") {
       var id = config.deviceToAddr(path[2]);
       if (discovery.inRange[id]) {
-       var device = discovery.inRange[id].peripheral;
-       var service = attributes.lookup(path[3].toLowerCase());
-       var charc = attributes.lookup(path[4].toLowerCase());
-       connect.read(device, service, charc, function(data) {
-         client.publish("/ble/data/"+path[2]+"/"+path[3]+"/"+path[4], data);
-       });
+        var device = discovery.inRange[id].peripheral;
+        if(path.length === 5) {
+        var service = attributes.lookup(path[3].toLowerCase());
+        var charc = attributes.lookup(path[4].toLowerCase());
+        connect.read(device, service, charc, function(data) {
+          client.publish("/ble/data/"+path[2]+"/"+path[3]+"/"+path[4], data);
+        });
+        } else if(path.length === 3) {
+          connect.readServices(device, function(data) {
+            client.publish("/ble/data/"+path[2], data);
+          });
+        } else {
+          log("Invalid number of topic levels");
+        }
       } else {
         log("Read from "+id+" but not in range");
       }


### PR DESCRIPTION
Hi Gordon, this pull request is to make it possible to scan services/characteristics. If a /read message coming in doesn't have service and characteristic uuids (is of the form /ble/read/DEVICE), it'll scan services and characteristics and send them out in an array on /ble/data/DEVICE in this format:

[
  {
    uuid:serviceUuid,
    characteristics: [
      {
        uuid:characteristicUuid
      }
    ]
  }
] 

The array could be simpler, but as it is it can have more details added later on without breaking people's code. 