### PR TITLE
fix discovery in ide when using remote mqtt server

### DIFF
--- a/lib/http.js
+++ b/lib/http.js
@@ -94,7 +94,9 @@ function mqttWebSocket(request) {
   log((new Date()) + ' Connection accepted.');
   var socket = new require("net").Socket();
 
-  socket.connect(1883, "localhost", function() {
+  var mqttHost = config.mqtt_host.split('//')[1];
+
+  socket.connect(1883, mqttHost, function() {
     log("Websocket MQTT connected");
   });
   socket.on('data', function(d) {


### PR DESCRIPTION
When mqtt_host was configured to anything else than the default `mqtt://localhost` device discovery in the web ide was broken.
`http.js` always tried to connect to an mqtt server on `localhost`.

This PR takes the `mqtt_host` property from config and removes the protocol section.

As port 1883 is still hard coded this will only work for `mqtt` hosts, not for `mqtts` hosts. As I do not have an `mqtts` host to test I did not touch that. 