### PR TITLE
Add a default client id for mqtt servers which require it

### DIFF
--- a/config.json
+++ b/config.json
@@ -37,6 +37,7 @@
   "//mqtt_host": "mqtts://example.duckdns.org",
   "//mqtt_options": {
     "username": "user",
-    "password": "pass"
+    "password": "pass",
+    "clientId": "clientid"
   }
 }


### PR DESCRIPTION
Relating to issue #35 