### PR TITLE
fix incorrect return of data on notify: warning potentially breaking change

### DIFF
--- a/lib/connect.js
+++ b/lib/connect.js
@@ -353,7 +353,7 @@ exports.notify = function(device, service, characteristic, callback) {
          //log(connection.name+": notification on "+data.toString());
          //new Uint8Array(data).buffer
          if (connection.services[serviceUUID][characteristicUUID].notifyCallback)
-           connection.services[serviceUUID][characteristicUUID].notifyCallback(data.toString());
+           connection.services[serviceUUID][characteristicUUID].notifyCallback(data);
        });
        char.subscribe(function() {
          connection.services[serviceUUID][characteristicUUID].notifyCallback = callback;


### PR DESCRIPTION
Data sent by bluetooth devices should not be constrained into a string. Fixes issue #42 
