### PR TITLE
MQTT prefix doesn't have to be 4 characters long

### DIFF
--- a/lib/mqttclient.js
+++ b/lib/mqttclient.js
@@ -65,67 +65,65 @@ function convertMessage(data) {
 }
 
 client.on('message', function (topic, message) {
-  if (topic.substr(0,5)==config.mqtt_prefix+"/") {
-    //log(topic+" => "+JSON.stringify(message.toString()));
-    var path = topic.substr(1).split("/");
-    if (path[1]=="write") {
-      var id = config.deviceToAddr(path[2]);
-      if (discovery.inRange[id]) {
-       var device = discovery.inRange[id].peripheral;
-       var service = attributes.lookup(path[3].toLowerCase());
-       var charc = attributes.lookup(path[4].toLowerCase());
-       connect.write(device, service, charc, convertMessage(message), function() {
-         client.publish(config.mqtt_prefix+"/written/"+id+"/"+path[3]+"/"+path[4], message);
-       });
-      } else {
-        log("Write to "+id+" but not in range");
-      }
+  //log(topic+" => "+JSON.stringify(message.toString()));
+  var path = topic.substr(1).split("/");
+  if (path[1]=="write") {
+    var id = config.deviceToAddr(path[2]);
+    if (discovery.inRange[id]) {
+     var device = discovery.inRange[id].peripheral;
+     var service = attributes.lookup(path[3].toLowerCase());
+     var charc = attributes.lookup(path[4].toLowerCase());
+     connect.write(device, service, charc, convertMessage(message), function() {
+       client.publish(config.mqtt_prefix+"/written/"+id+"/"+path[3]+"/"+path[4], message);
+     });
+    } else {
+      log("Write to "+id+" but not in range");
     }
-    if (path[1]=="read") {
-      var id = config.deviceToAddr(path[2]);
-      if (discovery.inRange[id]) {
-        var device = discovery.inRange[id].peripheral;
-        if(path.length === 5) {
-        var service = attributes.lookup(path[3].toLowerCase());
-        var charc = attributes.lookup(path[4].toLowerCase());
-        connect.read(device, service, charc, function(data) {
-          client.publish(config.mqtt_prefix+"/data/"+path[2]+"/"+path[3]+"/"+path[4], data);
+  }
+  if (path[1]=="read") {
+    var id = config.deviceToAddr(path[2]);
+    if (discovery.inRange[id]) {
+      var device = discovery.inRange[id].peripheral;
+      if(path.length === 5) {
+      var service = attributes.lookup(path[3].toLowerCase());
+      var charc = attributes.lookup(path[4].toLowerCase());
+      connect.read(device, service, charc, function(data) {
+        client.publish(config.mqtt_prefix+"/data/"+path[2]+"/"+path[3]+"/"+path[4], data);
+      });
+      } else if(path.length === 3) {
+        connect.readServices(device, function(data) {
+          client.publish(config.mqtt_prefix+"/data/"+path[2], data);
         });
-        } else if(path.length === 3) {
-          connect.readServices(device, function(data) {
-            client.publish(config.mqtt_prefix+"/data/"+path[2], data);
-          });
-        } else {
-          log("Invalid number of topic levels");
-        }
       } else {
-        log("Read from "+id+" but not in range");
+        log("Invalid number of topic levels");
       }
+    } else {
+      log("Read from "+id+" but not in range");
     }
-    if (path[1]=="notify") { // start notifications
-      var id = config.deviceToAddr(path[2]);
-      if (discovery.inRange[id]) {
-       var device = discovery.inRange[id].peripheral;
-       var service = attributes.lookup(path[3].toLowerCase());
-       var charc = attributes.lookup(path[4].toLowerCase());
-       connect.notify(device, service, charc, function(data) {
-         // data is a String
-         client.publish(config.mqtt_prefix+"/data/"+path[2]+"/"+path[3]+"/"+path[4], data);
-       });
-      } else {
-        log("Notify on "+id+" but not in range");
-      }
+  }
+  if (path[1]=="notify") { // start notifications
+    var id = config.deviceToAddr(path[2]);
+    if (discovery.inRange[id]) {
+     var device = discovery.inRange[id].peripheral;
+     var service = attributes.lookup(path[3].toLowerCase());
+     var charc = attributes.lookup(path[4].toLowerCase());
+     connect.notify(device, service, charc, function(data) {
+       // data is a String
+       client.publish(config.mqtt_prefix+"/data/"+path[2]+"/"+path[3]+"/"+path[4], data);
+     });
+    } else {
+      log("Notify on "+id+" but not in range");
     }
-    if (path[1]=="ping") { // open or keep a connection to a device open
-      var id = config.deviceToAddr(path[2]);
-      if (discovery.inRange[id]) {
-       var device = discovery.inRange[id].peripheral;
-       connect.ping(device, function() {
-         client.publish(config.mqtt_prefix+"/pong/"+path[2], message);
-       });
-      } else {
-        log("Ping "+id+" but not in range");
-      }
+  }
+  if (path[1]=="ping") { // open or keep a connection to a device open
+    var id = config.deviceToAddr(path[2]);
+    if (discovery.inRange[id]) {
+     var device = discovery.inRange[id].peripheral;
+     connect.ping(device, function() {
+       client.publish(config.mqtt_prefix+"/pong/"+path[2], message);
+     });
+    } else {
+      log("Ping "+id+" but not in range");
     }
   }
 });

--- a/lib/mqttclient.js
+++ b/lib/mqttclient.js
@@ -64,12 +64,8 @@ function convertMessage(data) {
   return data;
 }
 
-function topicStartsWithPrefix(topic) {
-  return topic.substr(0, config.mqtt_prefix.length + 1) === config.mqtt_prefix + "/";
-}
-
 client.on('message', function (topic, message) {
-  if (topicStartsWithPrefix(topic)) {
+  if (topic.startsWith(config.mqtt_prefix + "/")) {
     //log(topic+" => "+JSON.stringify(message.toString()));
     var path = topic.substr(1).split("/");
     if (path[1]=="write") {

--- a/lib/mqttclient.js
+++ b/lib/mqttclient.js
@@ -64,8 +64,12 @@ function convertMessage(data) {
   return data;
 }
 
+function topicStartsWithPrefix(topic) {
+  return topic.substr(0, config.mqtt_prefix.length + 1) === config.mqtt_prefix + "/";
+}
+
 client.on('message', function (topic, message) {
-  if (topic.substr(0,config.mqtt_prefix.length+1)===config.mqtt_prefix+"/") {
+  if (topicStartsWithPrefix(topic)) {
     //log(topic+" => "+JSON.stringify(message.toString()));
     var path = topic.substr(1).split("/");
     if (path[1]=="write") {

--- a/lib/mqttclient.js
+++ b/lib/mqttclient.js
@@ -65,65 +65,67 @@ function convertMessage(data) {
 }
 
 client.on('message', function (topic, message) {
-  //log(topic+" => "+JSON.stringify(message.toString()));
-  var path = topic.substr(1).split("/");
-  if (path[1]=="write") {
-    var id = config.deviceToAddr(path[2]);
-    if (discovery.inRange[id]) {
-     var device = discovery.inRange[id].peripheral;
-     var service = attributes.lookup(path[3].toLowerCase());
-     var charc = attributes.lookup(path[4].toLowerCase());
-     connect.write(device, service, charc, convertMessage(message), function() {
-       client.publish(config.mqtt_prefix+"/written/"+id+"/"+path[3]+"/"+path[4], message);
-     });
-    } else {
-      log("Write to "+id+" but not in range");
-    }
-  }
-  if (path[1]=="read") {
-    var id = config.deviceToAddr(path[2]);
-    if (discovery.inRange[id]) {
-      var device = discovery.inRange[id].peripheral;
-      if(path.length === 5) {
-      var service = attributes.lookup(path[3].toLowerCase());
-      var charc = attributes.lookup(path[4].toLowerCase());
-      connect.read(device, service, charc, function(data) {
-        client.publish(config.mqtt_prefix+"/data/"+path[2]+"/"+path[3]+"/"+path[4], data);
-      });
-      } else if(path.length === 3) {
-        connect.readServices(device, function(data) {
-          client.publish(config.mqtt_prefix+"/data/"+path[2], data);
-        });
+  if (topic.substr(0,config.mqtt_prefix.length+1)===config.mqtt_prefix+"/") {
+    //log(topic+" => "+JSON.stringify(message.toString()));
+    var path = topic.substr(1).split("/");
+    if (path[1]=="write") {
+      var id = config.deviceToAddr(path[2]);
+      if (discovery.inRange[id]) {
+       var device = discovery.inRange[id].peripheral;
+       var service = attributes.lookup(path[3].toLowerCase());
+       var charc = attributes.lookup(path[4].toLowerCase());
+       connect.write(device, service, charc, convertMessage(message), function() {
+         client.publish(config.mqtt_prefix+"/written/"+id+"/"+path[3]+"/"+path[4], message);
+       });
       } else {
-        log("Invalid number of topic levels");
+        log("Write to "+id+" but not in range");
       }
-    } else {
-      log("Read from "+id+" but not in range");
     }
-  }
-  if (path[1]=="notify") { // start notifications
-    var id = config.deviceToAddr(path[2]);
-    if (discovery.inRange[id]) {
-     var device = discovery.inRange[id].peripheral;
-     var service = attributes.lookup(path[3].toLowerCase());
-     var charc = attributes.lookup(path[4].toLowerCase());
-     connect.notify(device, service, charc, function(data) {
-       // data is a String
-       client.publish(config.mqtt_prefix+"/data/"+path[2]+"/"+path[3]+"/"+path[4], data);
-     });
-    } else {
-      log("Notify on "+id+" but not in range");
+    if (path[1]=="read") {
+      var id = config.deviceToAddr(path[2]);
+      if (discovery.inRange[id]) {
+        var device = discovery.inRange[id].peripheral;
+        if(path.length === 5) {
+        var service = attributes.lookup(path[3].toLowerCase());
+        var charc = attributes.lookup(path[4].toLowerCase());
+        connect.read(device, service, charc, function(data) {
+          client.publish(config.mqtt_prefix+"/data/"+path[2]+"/"+path[3]+"/"+path[4], data);
+        });
+        } else if(path.length === 3) {
+          connect.readServices(device, function(data) {
+            client.publish(config.mqtt_prefix+"/data/"+path[2], data);
+          });
+        } else {
+          log("Invalid number of topic levels");
+        }
+      } else {
+        log("Read from "+id+" but not in range");
+      }
     }
-  }
-  if (path[1]=="ping") { // open or keep a connection to a device open
-    var id = config.deviceToAddr(path[2]);
-    if (discovery.inRange[id]) {
-     var device = discovery.inRange[id].peripheral;
-     connect.ping(device, function() {
-       client.publish(config.mqtt_prefix+"/pong/"+path[2], message);
-     });
-    } else {
-      log("Ping "+id+" but not in range");
+    if (path[1]=="notify") { // start notifications
+      var id = config.deviceToAddr(path[2]);
+      if (discovery.inRange[id]) {
+       var device = discovery.inRange[id].peripheral;
+       var service = attributes.lookup(path[3].toLowerCase());
+       var charc = attributes.lookup(path[4].toLowerCase());
+       connect.notify(device, service, charc, function(data) {
+         // data is a String
+         client.publish(config.mqtt_prefix+"/data/"+path[2]+"/"+path[3]+"/"+path[4], data);
+       });
+      } else {
+        log("Notify on "+id+" but not in range");
+      }
+    }
+    if (path[1]=="ping") { // open or keep a connection to a device open
+      var id = config.deviceToAddr(path[2]);
+      if (discovery.inRange[id]) {
+       var device = discovery.inRange[id].peripheral;
+       connect.ping(device, function() {
+         client.publish(config.mqtt_prefix+"/pong/"+path[2], message);
+       });
+      } else {
+        log("Ping "+id+" but not in range");
+      }
     }
   }
 });

--- a/www/ide.html
+++ b/www/ide.html
@@ -110,9 +110,10 @@ Loading IDE...</iframe>
       } else if (deviceAddress && message.destinationName == mqtt_prefix+"/written/"+deviceAddress+"/nus/nus_tx") {
         if (onDataWritten) onDataWritten();
         onDataWritten = undefined;
-      } else if (message.destinationName.substr(0,15)==mqtt_prefix+"/advertise/") {
+      } else if (message.destinationName.startsWith(mqtt_prefix+"/advertise/")) {
         // advertising for new devices
-        var address = message.destinationName.substr(15);
+        var topic_prefix = mqtt_prefix+"/advertise/";
+        var address = message.destinationName.substr(topic_prefix.length);
         try {
           var j = JSON.parse(message.payloadString);
           var isEspruino = false;


### PR DESCRIPTION
This line is presumably meant to check that we're only receiving message with prefix at the start, but it requires the prefix to be exactly 4 characters. This would work for the current default `"/ble"`, but the docs suggest using `"ble"`, which is the wrong number of characters.

```
client.subscribe(config.mqtt_prefix+"/write/#");
client.subscribe(config.mqtt_prefix+"/read/#");
client.subscribe(config.mqtt_prefix+"/notify/#");
client.subscribe(config.mqtt_prefix+"/ping/#");
```

As we're only subscribing to topics that start with the prefix, I don't think the check is required anyway, so I've just removed it.