### PR TITLE
Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,33 @@
+FROM balenalib/rpi-raspbian:latest
+
+ARG ARCH=armv6l
+ARG NODE_VERSION=8.17.0
+
+RUN apt-get update \
+ && apt-get install -y bluetooth \
+                       bluez \
+                       libbluetooth-dev \
+                       libudev-dev \
+                       mosquitto-clients \
+                       git \
+                       build-essential \
+                       python3 \
+                       ca-certificates \
+ && apt-get clean
+
+RUN update-ca-certificates --fresh
+
+RUN curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-$ARCH.tar.gz" \
+ && tar -xzf "node-v$NODE_VERSION-linux-$ARCH.tar.gz" -C /usr/local --strip-components=1 \
+ && rm "node-v$NODE_VERSION-linux-$ARCH.tar.gz"
+
+RUN git clone https://github.com/espruino/EspruinoHub
+
+WORKDIR /EspruinoHub
+
+RUN npm install \
+ && npm cache clean --force
+
+VOLUME ["/EspruinoHub/log"]
+
+ENTRYPOINT ["node", "index.js"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,6 @@ RUN apt-get update \
                        libbluetooth-dev \
                        libudev-dev \
                        mosquitto-clients \
-                       git \
                        build-essential \
                        python3 \
                        ca-certificates \
@@ -21,7 +20,7 @@ RUN curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-
  && tar -xzf "node-v$NODE_VERSION-linux-$ARCH.tar.gz" -C /usr/local --strip-components=1 \
  && rm "node-v$NODE_VERSION-linux-$ARCH.tar.gz"
 
-RUN git clone https://github.com/espruino/EspruinoHub
+ADD / /EspruinoHub
 
 WORKDIR /EspruinoHub
 

--- a/README.md
+++ b/README.md
@@ -132,6 +132,17 @@ sudo rm /etc/systemd/system/EspruinoHub.service
 sudo rm -rf ~/EspruinoHub
 ```
 
+Run with Docker
+---------------
+
+Build on Raspberry Pi Zero:
+
+    docker build -t espruino/espruinohub:armhf https://github.com/espruino/EspruinoHub.git
+
+Run from the directory containing your `config.json`:
+
+    docker run -d -v $PWD/config.json:/EspruinoHub/config.json:ro --restart=always --net=host --name espruinohub espruino/espruinohub:armhf
+
 Usage
 -----
 


### PR DESCRIPTION
Closes #16.

This is what I've been running on a Raspberry Pi Zero W with Raspbian/Raspberry Pi OS for the last few weeks.

The idea is that the architecture is a build argument that can be passed in, so you ought to be able to pass in `armv7l` to build on a Pi 3 (or 4?).
The Node version is also an argument at the moment, although maybe we should decide which is the version people should be using.

I'm currently installing all the Bluetooth packages, but I'm not how much of that is required if you run the container with `--net=host`, so it has full access to the host's networking. See https://github.com/espruino/EspruinoHub/issues/16#issuecomment-632806675.

I'll add something like this to the README:

Build container:

    docker build -t espruino/espruinohub:armhf https://github.com/espruino/EspruinoHub.git

Run:

    docker run -d -v $PWD/config.json:/EspruinoHub/config.json:ro --restart=always --net=host --name espruinohub espruino/espruinohub:armhf

The build could even be done by CI on Github, so people can just pull the image and use it without having to build themselves (it takes a pretty long time on a Pi Zero).