### PR TITLE
Pass advertising errors to handler

### DIFF
--- a/lib/service.js
+++ b/lib/service.js
@@ -189,9 +189,7 @@ function httpStateHandler(state) {
 function onStateChange(state) {
   log("Bleno State "+state);
   if (state == "poweredOn") {
-    bleno.startAdvertising("EspruinoHub", ['1823'], function (error) {
-      onAdvertisingStart();
-    });
+    bleno.startAdvertising("EspruinoHub", ['1823'], onAdvertisingStart);
   }
 }
 


### PR DESCRIPTION
`onAdvertisingStart()` expects `error` to be passed as the first parameter, but it never is.