### PR TITLE
Xiaomi parser fe95

### DIFF
--- a/lib/attributes.js
+++ b/lib/attributes.js
@@ -13,67 +13,9 @@
  * ----------------------------------------------------------------------------
  */
 
-var config = require("./config");
-const util = require("./util");
-
-const xiaomiProductName = {
-  0x005d: "HHCCPOT002",
-  0x0098: "HHCCJCY01",
-  0x01d8: "Stratos",
-  0x02df: "JQJCY01YM",
-  0x03b6: "YLKG08YL",
-  0x03bc: "GCLS002",
-  0x040a: "WX08ZM",
-  0x045b: "LYWSD02",
-  0x055b: "LYWSD03MMC",
-  0x0576: "CGD1",
-  0x0347: "CGG1",
-  0x01aa: "LYWSDCGQ",
-  0x03dd: "MUE4094RT",
-  0x07f6: "MJYD02YLA",
-  0x0387: "MHOC401"
-}
-
-function parseXiaomiValue(type, data, length, r) {
-  switch (type) {
-    case 0x04: { // temperature, 2 bytes, 16-bit signed integer (LE)
-      let temp = data[1] << 8 | data[0];
-      if (temp & 0x8000) temp -= 0x10000;
-      r.temp = temp / 10;
-      break;
-    }
-    case 0x06: { // humidity, 2 bytes, 16-bit signed integer (LE)
-      r.humidity = (data[1] << 8 | data[0]) / 10;
-      break;
-    }
-    case 0x0a: { // battery, 1 byte, 8-bit unsigned integer
-      r.battery = data[0];
-      break;
-    }
-    case 0x0d: { // temperature+humidity, 4 bytes, 16-bit signed integer (LE)
-      let temp = data[1] << 8 | data[0];
-      if (temp & 0x8000) temp -= 0x10000;
-      r.temp     = temp / 10;
-      r.humidity = (data[3] << 8 | data[2]) / 10;
-      break;
-    }
-    case 0x09: {  // conductivity, 2 bytes, 16-bit unsigned integer (LE), 1 µS/cm
-      if (length !== 2) break;
-      r.conductivity = data[1] << 8 | data[0];
-      break;
-    }
-    case 0x07: {  // illuminance, 3 bytes, 24-bit unsigned integer (LE), 1 lx
-      if (length !== 3) break;
-      r.illuminance = data[2] << 16 | data[1] << 8 | data[0];
-      break;
-    }
-    case 0x08: {  // soil moisture, 1 byte, 8-bit unsigned integer, 1 %
-      if (length !== 1) break;
-      r.moisture = data[0];
-      break;
-    }
-  }
-}
+var config     = require("./config");
+const util     = require("./util");
+const miParser = require("./parsers/xiaomi").Parser;
 
 exports.names = {
   // https://www.bluetooth.com/specifications/gatt/services/
@@ -188,7 +130,7 @@ exports.handlers = {
       loadRemoved: (status[7] !== 0)
     };
 
-    const date = {
+    const d  = {
       year: a.readUInt16LE(3),
       month: a.readUInt8(5),
       day: a.readUInt8(6),
@@ -196,26 +138,16 @@ exports.handlers = {
       minute: a.readUInt8(8),
       second: a.readUInt8(9)
     }
-    return {weight: util.toFixedFloat(weight, 2), unit, ...state, ...date};
+    let date = new Date(d.year, d.month - 1, d.day, d.hour, d.minute, d.second);
+    return {weight: util.toFixedFloat(weight, 2), unit, ...state, date};
   },
-  "fe95": function (d) {
-    var frameControl = (d[1] << 8) + d[0];
-    var productId    = (d[3] << 8) + d[2];
-    var counter      = d[4];
-    var r            = {
-      frameControl: frameControl,
-      productId: productId,
-      counter: counter
-    };
-    if (xiaomiProductName[productId] !== undefined) r.productName = xiaomiProductName[productId];
-
-    const rawOffset  = productId === 0x01aa || productId === 0x055b ? 11 : 12;
-    const dataType   = d[rawOffset];
-    const dataLength = d[rawOffset + 2];
-    const data       = d.slice(rawOffset + 3);
-
-    parseXiaomiValue(dataType, data, dataLength, r);
-    return r;
+  "fe95": function (d, device) {
+    try {
+      const r = new miParser(d, device ? device.bind_key : null).parse();
+      return {...r.event, productName: r.productName};
+    } catch (e) {
+      return {error: e.message};
+    }
   },
   "fee0": function (d) {
     let r = {steps: (0xff & d[0] | (0xff & d[1]) << 8)};
@@ -256,11 +188,11 @@ exports.handlers = {
   },
   "2a56": function (a) { // org.bluetooth.characteristic.digital
     // probably not meant for advertising, but seems useful!
-    return {digital: a[0]!=0}
+    return {digital: a[0] != 0}
   },
   "2a58": function (a) { // org.bluetooth.characteristic.analog
     // probably not meant for advertising, but seems useful!
-    return {analog: a[0] | (a.length>1 ? (a[1]<<8) : 0)}
+    return {analog: a[0] | (a.length > 1 ? (a[1] << 8) : 0)}
   },
   // org.bluetooth.characteristic.digital_output	0x2A57 ?
   "ffff": function (a) { // 0xffff isn't standard anything - just transmit it as 'data'
@@ -276,26 +208,28 @@ exports.getReadableAttributeName = function (attr) {
   return attr;
 };
 
-exports.decodeAttribute = function (name, value) {
-  // built-in decoders
-  if (name in exports.handlers) {
-    var r = exports.handlers[name](value);
-    return r ? r : value;
-  }
+exports.decodeAttribute = function (name, value, device) {
+  if (!(name in config.exclude_services)) { // @todo per device
+    // built-in decoders
+    if (name in exports.handlers) {
+      var r = exports.handlers[name](value, device);
+      return r ? r : value;
+    }
 
-  // use generic decoder for known services
-  if (name in exports.names) {
-    var obj                  = {};
-    obj[exports.names[name]] = value;
-    return obj;
-  }
+    // use generic decoder for known services
+    if (name in exports.names) {
+      var obj                  = {};
+      obj[exports.names[name]] = value;
+      return obj;
+    }
 
-  // look up decoders in config.json
-  if (name in config.advertised_services) {
-    var srv       = config.advertised_services[name];
-    var obj       = {};
-    obj[srv.name] = value[0];
-    return obj;
+    // look up decoders in config.json
+    if (name in config.advertised_services) {
+      var srv       = config.advertised_services[name];
+      var obj       = {};
+      obj[srv.name] = value[0];
+      return obj;
+    }
   }
   // otherwise as-is
   return value;

--- a/lib/attributes.js
+++ b/lib/attributes.js
@@ -146,7 +146,7 @@ exports.handlers = {
       const r = new miParser(d, device ? device.bind_key : null).parse();
       return {...r.event, productName: r.productName};
     } catch (e) {
-      return {error: e.message};
+      console.error({error: e.message, raw: d.toString("hex")});
     }
   },
   "fee0": function (d) {

--- a/lib/discovery.js
+++ b/lib/discovery.js
@@ -131,39 +131,7 @@ async function onDiscovery(peripheral) {
     mqtt.send(dev.advertise_topic, JSON.stringify(mqttData));
   }
 
-  peripheral.advertisement.serviceData.forEach(function (d) {
-    /* Don't keep sending the same old data on MQTT. Only send it if
-    it's changed or >1 minute old. */
-    if (inRange[addr].data[d.uuid] &&
-      inRange[addr].data[d.uuid].payload.toString() === d.data.toString() &&
-      inRange[addr].data[d.uuid].time > Date.now() - 60000)
-      return;
 
-    if (config.mqtt_advertise_service_data) {
-      // Send advertising data as a simple JSON array, eg. "[1,2,3]"
-      var byteData = [];
-      for (var i = 0; i < d.data.length; i++)
-        byteData.push(d.data.readUInt8(i));
-      mqtt.send(dev.advertise_topic + "/" + d.uuid, JSON.stringify(byteData));
-    }
-
-    inRange[addr].data[d.uuid] = {payload: d.data, time: Date.now()};
-
-    var decoded = attributes.decodeAttribute(d.uuid, d.data, dev);
-    if (decoded !== d.data) {
-      decoded.rssi = peripheral.rssi;
-      dev.filterAttributes(decoded);
-
-      if (config.homeassistant) homeassistant.configDiscovery(decoded, dev, peripheral, d.uuid);
-      for (var k in decoded) {
-        if (config.mqtt_format_decoded_key_topic) mqtt.send(config.mqtt_prefix + "/" + k + "/" + id, JSON.stringify(decoded[k]));
-      }
-
-      if (config.mqtt_format_json) {
-        mqtt.send(dev.json_state_topic + "/" + d.uuid, JSON.stringify(dev.getOrSetState(d.uuid, decoded)));
-      }
-    }
-  });
   if(peripheral.advertisement.serviceData) {
     peripheral.advertisement.serviceData.forEach(function (d) {
       /* Don't keep sending the same old data on MQTT. Only send it if
@@ -178,27 +146,24 @@ async function onDiscovery(peripheral) {
         var byteData = [];
         for (var i = 0; i < d.data.length; i++)
           byteData.push(d.data.readUInt8(i));
-        mqtt.send(config.mqtt_prefix + "/advertise/" + id + "/" + d.uuid, JSON.stringify(byteData));
+        mqtt.send(dev.advertise_topic + "/" + d.uuid, JSON.stringify(byteData));
       }
 
       inRange[addr].data[d.uuid] = {payload: d.data, time: Date.now()};
 
-      var decoded = attributes.decodeAttribute(d.uuid, d.data);
+      var decoded = attributes.decodeAttribute(d.uuid, d.data, dev);
       if (decoded !== d.data) {
         decoded.rssi = peripheral.rssi;
-        if (config.homeassistant) homeassistant.configDiscovery(decoded, peripheral, d.uuid);
+        dev.filterAttributes(decoded);
+
+        if (config.homeassistant) homeassistant.configDiscovery(decoded, dev, peripheral, d.uuid);
         for (var k in decoded) {
           if (config.mqtt_advertise) mqtt.send(config.mqtt_prefix + "/advertise/" + id + "/" + k, JSON.stringify(decoded[k]));
           if (config.mqtt_format_decoded_key_topic) mqtt.send(config.mqtt_prefix + "/" + k + "/" + id, JSON.stringify(decoded[k]));
         }
 
         if (config.mqtt_format_json) {
-          let state = decoded;
-          if (stateCache[addr + d.uuid] !== undefined) {
-            state = {...stateCache[addr + d.uuid], ...state};
-          }
-          stateCache[addr + d.uuid] = state;
-          mqtt.send(config.mqtt_prefix + "/json/" + id + "/" + d.uuid, JSON.stringify(state));
+          mqtt.send(dev.json_state_topic + "/" + d.uuid, JSON.stringify(dev.getOrSetState(d.uuid, decoded)));
         }
       }
     });

--- a/lib/homeassistant.js
+++ b/lib/homeassistant.js
@@ -41,6 +41,10 @@ const deviceTypes   = {
     unit_of_measurement: "%",
     icon: "mdi:water-percent"
   },
+  motion: {
+    device_class: "motion",
+    off_delay: 30
+  },
   conductivity: { // µS/cm
     unit_of_measurement: "µS/cm",
     icon: "mdi:flower"
@@ -54,7 +58,7 @@ const deviceTypes   = {
   level: {},
   data: {}
 }
-const binaryDevices = ["digital"];
+const binaryDevices = ["digital", "motion"];
 
 let discoverySend = {};
 

--- a/lib/homeassistant.js
+++ b/lib/homeassistant.js
@@ -1,7 +1,11 @@
-const mqtt        = require("./mqttclient");
-const config      = require("./config");
-const deviceTypes = {
+const mqtt          = require("./mqttclient");
+const config        = require("./config");
+const deviceTypes   = {
   temp: {
+    unit_of_measurement: "°C",
+    device_class: "temperature"
+  },
+  temperature: {
     unit_of_measurement: "°C",
     device_class: "temperature"
   },
@@ -45,16 +49,12 @@ const deviceTypes = {
     unit_of_measurement: "dBm",
     device_class: "signal_strength"
   },
-  digital: {
-  },
-  analog: {
-  },
-  level: {
-  },
-  data: {
-  }
+  digital: {},
+  analog: {},
+  level: {},
+  data: {}
 }
-const binaryDevices = [ "digital" ];
+const binaryDevices = ["digital"];
 
 let discoverySend = {};
 
@@ -69,10 +69,10 @@ exports.configDiscovery = function (data, device, peripheral, serviceId) {
     if (deviceTypes[dataKey] !== undefined && !discoverySend[id + serviceId + dataKey]) {
       let component, valueTemplate;
       if (binaryDevices.includes(dataKey)) {
-        component = "binary_sensor";
-        valueTemplate = '{{ "ON" if float(value_json.' + dataKey + ')!=0 else "OFF" }}';
+        component     = "binary_sensor";
+        valueTemplate = "{{ \"ON\" if float(value_json." + dataKey + ")!=0 else \"OFF\" }}";
       } else {
-        component = "sensor";
+        component     = "sensor";
         valueTemplate = "{{ value_json." + dataKey + "}}";
       }
       let configTopic = `homeassistant/${component}/${uuid}/${serviceId}_${dataKey}/config`

--- a/lib/parsers/xiaomi.js
+++ b/lib/parsers/xiaomi.js
@@ -28,6 +28,8 @@ const CapabilityFlags = {
 };
 
 const EventTypes = {
+  easyPairing: 0x0002,
+  button: 0x1001,
   temperature: 4100,
   humidity: 4102,
   illuminance: 4103,
@@ -41,6 +43,7 @@ const xiaomiProductName = {
   0x005d: "HHCCPOT002",
   0x0098: "HHCCJCY01",
   0x01d8: "Stratos",
+  0x0153: "YEE-RC",
   0x02df: "JQJCY01YM",
   0x03b6: "YLKG08YL",
   0x03bc: "GCLS002",
@@ -226,6 +229,12 @@ class Parser {
       return null;
     }
     switch (this.eventType) {
+      case EventTypes.easyPairing: {
+        return this.parseEasyPairing();
+      }
+      case EventTypes.button: {
+        return this.parseButton();
+      }
       case EventTypes.temperature: {
         return this.parseTemperatureEvent();
       }
@@ -249,7 +258,7 @@ class Parser {
       }
       default: {
         throw new Error(
-          `Unknown event type: ${this.eventType}. ${this.toString()}`
+          `Unknown event type: ${this.eventType}. ${this.toString()} - ${this.buffer.slice(this.eventOffset)}`
         );
       }
     }
@@ -299,6 +308,25 @@ class Parser {
 
   toString() {
     return this.buffer.toString("hex");
+  }
+
+  parseButton() {
+    const actions = Object.freeze({
+      0x00: "single",
+      0x01: "double",
+      0x02: "long_press",
+      0x03: "triple"
+    });
+    const button  = this.buffer.readInt16LE(this.eventOffset + 3);
+    const action  = this.buffer.readInt8(this.eventOffset + 5);
+    return {
+      button,
+      action: actions[action] || null
+    };
+  }
+
+  parseEasyPairing() {
+    return {objectID: this.buffer.readInt16LE(this.eventOffset + 3)};
   }
 }
 

--- a/lib/parsers/xiaomi.js
+++ b/lib/parsers/xiaomi.js
@@ -30,6 +30,9 @@ const CapabilityFlags = {
 const EventTypes = {
   easyPairing: 0x0002,
   button: 0x1001,
+  movingWithLight: 0x000F,//0x000F // Someone is moving (with light)
+  //0x1017 //  No one moves
+  //0x1018 // Light intensity
   temperature: 4100,
   humidity: 4102,
   illuminance: 4103,
@@ -256,6 +259,9 @@ class Parser {
       case EventTypes.moisture: {
         return this.parseMoistureEvent();
       }
+      case EventTypes.movingWithLight: {
+        return this.parseMovingWithLightEvent();
+      }
       default: {
         throw new Error(
           `Unknown event type: ${this.eventType}. ${this.toString()} - ${this.buffer.slice(this.eventOffset)}`
@@ -303,6 +309,14 @@ class Parser {
   parseMoistureEvent() {
     return {
       moisture: this.buffer.readInt8(this.eventOffset + 3)
+    };
+  }
+
+  parseMovingWithLightEvent() {
+    //@todo Qingping light
+    return {
+      motion: 1,
+      illuminance: this.buffer.readUIntLE(this.eventOffset + 3, 3)
     };
   }
 

--- a/lib/parsers/xiaomi.js
+++ b/lib/parsers/xiaomi.js
@@ -1,0 +1,309 @@
+/**
+ * This parser was originally ported from:
+ *
+ * https://github.com/hannseman/homebridge-mi-hygrothermograph/blob/master/lib/parser.js
+ */
+const crypto = require("crypto");
+
+const SERVICE_DATA_UUID = "fe95";
+
+const FrameControlFlags = {
+  isFactoryNew: 1 << 0,
+  isConnected: 1 << 1,
+  isCentral: 1 << 2,
+  isEncrypted: 1 << 3,
+  hasMacAddress: 1 << 4,
+  hasCapabilities: 1 << 5,
+  hasEvent: 1 << 6,
+  hasCustomData: 1 << 7,
+  hasSubtitle: 1 << 8,
+  hasBinding: 1 << 9
+};
+
+const CapabilityFlags = {
+  connectable: 1 << 0,
+  central: 1 << 1,
+  secure: 1 << 2,
+  io: (1 << 3) | (1 << 4)
+};
+
+const EventTypes = {
+  temperature: 4100,
+  humidity: 4102,
+  illuminance: 4103,
+  moisture: 4104,
+  fertility: 4105,
+  battery: 4106,
+  temperatureAndHumidity: 4109
+};
+
+const xiaomiProductName = {
+  0x005d: "HHCCPOT002",
+  0x0098: "HHCCJCY01",
+  0x01d8: "Stratos",
+  0x02df: "JQJCY01YM",
+  0x03b6: "YLKG08YL",
+  0x03bc: "GCLS002",
+  0x040a: "WX08ZM",
+  0x045b: "LYWSD02",
+  0x055b: "LYWSD03MMC",
+  0x0576: "CGD1",
+  0x0347: "CGG1",
+  0x01aa: "LYWSDCGQ",
+  0x03dd: "MUE4094RT",
+  0x07f6: "MJYD02YLA",
+  0x0387: "MHOC401"
+};
+
+class Parser {
+  constructor(buffer, bindKey = null) {
+    this.baseByteLength = 5;
+    if (buffer == null) {
+      throw new Error("A buffer must be provided.");
+    }
+    this.buffer = buffer;
+    if (buffer.length < this.baseByteLength) {
+      throw new Error(
+        `Service data length must be >= 5 bytes. ${this.toString()}`
+      );
+    }
+    this.bindKey = bindKey;
+  }
+
+  parse() {
+    this.frameControl = this.parseFrameControl();
+    this.version      = this.parseVersion();
+    this.productId    = this.parseProductId();
+    this.frameCounter = this.parseFrameCounter();
+    this.macAddress   = this.parseMacAddress();
+    this.capabilities = this.parseCapabilities();
+
+    if (this.frameControl.isEncrypted) {
+      this.decryptPayload();
+    }
+
+    this.eventType   = this.parseEventType();
+    this.eventLength = this.parseEventLength();
+    this.event       = this.parseEventData();
+    this.productName = xiaomiProductName[this.productId] || null;
+
+    return {
+      frameControl: this.frameControl,
+      event: this.event,
+      productId: this.productId,
+      frameCounter: this.frameCounter,
+      macAddress: this.macAddress,
+      eventType: this.eventType,
+      capabilities: this.capabilities,
+      eventLength: this.eventLength,
+      version: this.version
+    };
+  }
+
+  parseFrameControl() {
+    const frameControl = this.buffer.readUInt16LE(0);
+    return Object.keys(FrameControlFlags).reduce((map, flag) => {
+      map[flag] = (frameControl & FrameControlFlags[flag]) !== 0;
+      return map;
+    }, {});
+  }
+
+  parseVersion() {
+    return this.buffer.readUInt8(1) >> 4;
+  }
+
+  parseProductId() {
+    return this.buffer.readUInt16LE(2);
+  }
+
+  parseFrameCounter() {
+    return this.buffer.readUInt8(4);
+  }
+
+  parseMacAddress() {
+    if (!this.frameControl.hasMacAddress) {
+      return null;
+    }
+    const macBuffer = this.buffer.slice(
+      this.baseByteLength,
+      this.baseByteLength + 6
+    );
+    return Buffer.from(macBuffer)
+      .reverse()
+      .toString("hex");
+  }
+
+  get capabilityOffset() {
+    if (!this.frameControl.hasMacAddress) {
+      return this.baseByteLength;
+    }
+    return 11;
+  }
+
+  parseCapabilities() {
+    if (!this.frameControl.hasCapabilities) {
+      return null;
+    }
+    const capabilities = this.buffer.readUInt8(this.capabilityOffset);
+    return Object.keys(CapabilityFlags).reduce((map, flag) => {
+      map[flag] = (capabilities & CapabilityFlags[flag]) !== 0;
+      return map;
+    }, {});
+  }
+
+  get eventOffset() {
+    let offset = this.baseByteLength;
+    if (this.frameControl.hasMacAddress) {
+      offset = 11;
+    }
+    if (this.frameControl.hasCapabilities) {
+      offset += 1;
+    }
+
+    return offset;
+  }
+
+  parseEventType() {
+    if (!this.frameControl.hasEvent) {
+      return null;
+    }
+    return this.buffer.readUInt16LE(this.eventOffset);
+  }
+
+  parseEventLength() {
+    if (!this.frameControl.hasEvent) {
+      return null;
+    }
+    return this.buffer.readUInt8(this.eventOffset + 2);
+  }
+
+  decryptPayload() {
+    const msgLength   = this.buffer.length;
+    const eventLength = msgLength - this.eventOffset;
+
+    if (eventLength < 3) {
+      return;
+    }
+    if (this.bindKey == null) {
+      throw Error("Sensor data is encrypted. Please configure a bindKey.");
+    }
+
+    const encryptedPayload = this.buffer.slice(this.eventOffset, msgLength);
+
+    const nonce = Buffer.concat([
+      this.buffer.slice(5, 11), //mac_reversed
+      this.buffer.slice(2, 4), //device_type
+      this.buffer.slice(4, 5), //frame_cnt
+      encryptedPayload.slice(-7, -4) //ext_cnt
+    ]);
+
+    const decipher = crypto.createDecipheriv(
+      "aes-128-ccm",
+      Buffer.from(this.bindKey, "hex"), //key
+      nonce, //iv
+      {authTagLength: 4}
+    );
+
+    const ciphertext = encryptedPayload.slice(0, -7);
+
+    decipher.setAuthTag(encryptedPayload.slice(-4));
+    decipher.setAAD(Buffer.from("11", "hex"), {
+      plaintextLength: ciphertext.length
+    });
+
+    const receivedPlaintext = decipher.update(ciphertext);
+
+    decipher.final();
+
+    this.buffer = Buffer.concat([
+      this.buffer.slice(0, this.eventOffset),
+      receivedPlaintext
+    ]);
+  }
+
+  parseEventData() {
+    if (!this.frameControl.hasEvent) {
+      return null;
+    }
+    switch (this.eventType) {
+      case EventTypes.temperature: {
+        return this.parseTemperatureEvent();
+      }
+      case EventTypes.humidity: {
+        return this.parseHumidityEvent();
+      }
+      case EventTypes.battery: {
+        return this.parseBatteryEvent();
+      }
+      case EventTypes.temperatureAndHumidity: {
+        return this.parseTemperatureAndHumidityEvent();
+      }
+      case EventTypes.illuminance: {
+        return this.parseIlluminanceEvent();
+      }
+      case EventTypes.fertility: {
+        return this.parseFertilityEvent();
+      }
+      case EventTypes.moisture: {
+        return this.parseMoistureEvent();
+      }
+      default: {
+        throw new Error(
+          `Unknown event type: ${this.eventType}. ${this.toString()}`
+        );
+      }
+    }
+  }
+
+  parseTemperatureEvent() {
+    return {
+      temperature: this.buffer.readInt16LE(this.eventOffset + 3) / 10
+    };
+  }
+
+  parseHumidityEvent() {
+    return {
+      humidity: this.buffer.readUInt16LE(this.eventOffset + 3) / 10
+    };
+  }
+
+  parseBatteryEvent() {
+    return {
+      battery: this.buffer.readUInt8(this.eventOffset + 3)
+    };
+  }
+
+  parseTemperatureAndHumidityEvent() {
+    const temperature = this.buffer.readInt16LE(this.eventOffset + 3) / 10;
+    const humidity    = this.buffer.readUInt16LE(this.eventOffset + 5) / 10;
+    return {temperature, humidity};
+  }
+
+  parseIlluminanceEvent() {
+    return {
+      illuminance: this.buffer.readUIntLE(this.eventOffset + 3, 3)
+    };
+  }
+
+  parseFertilityEvent() {
+    return {
+      fertility: this.buffer.readInt16LE(this.eventOffset + 3)
+    };
+  }
+
+  parseMoistureEvent() {
+    return {
+      moisture: this.buffer.readInt8(this.eventOffset + 3)
+    };
+  }
+
+  toString() {
+    return this.buffer.toString("hex");
+  }
+}
+
+module.exports = {
+  Parser,
+  EventTypes,
+  SERVICE_DATA_UUID
+};


### PR DESCRIPTION
The fe95 parser has been moved to a separate file.

It is used in many projects, but the original seems to start at https://github.com/hannseman/homebridge-mi-hygrothermograph/blob/master/lib/parser.js

Improved device support in the parser
YEERC console - no encryption
I have a remote with and without encryption. Unfortunately, I was unable to decrypt messages on node js, crypto requires an authTag for verification, and the device does not send it. Absolutely identical python code works without verification using a different method. I will post the code developments in a separate branch, maybe someone can finish

Night light MJYD02YL-A with motion sensor.

The parser was checked for

- LYWSDCGQ
- LYWSD02
- LYWSD03MMC
- HHCCJCY01 MiFlora, Huahuacaocao
- MJYD02YL-A
- YEERC

They will most likely work if you write bind_key to decrypt messages.

- CGG1
- MHO-C401
- CGD1
- CGDK2
- or others

You can get bind_key in different ways, most of them are described here https://esphome.io/components/sensor/xiaomi_ble.html#other-encrypted-devices
If you have a homeassistant, then the keys can be obtained from the cloud using the https://github.com/AlexxIT/XiaomiGateway3 component (you do not need to have gateway 3)