### PR TITLE
fe95 legacy decrypt for YLYK01YL, YLKG07YL/YLKG08YL and more

### DIFF
--- a/lib/parsers/xiaomi.js
+++ b/lib/parsers/xiaomi.js
@@ -85,7 +85,11 @@ class Parser {
     this.capabilities = this.parseCapabilities();
 
     if (this.frameControl.isEncrypted) {
-      this.decryptPayload();
+      if (this.version <= 3) {
+        this.decryptLegacyPayload();
+      } else {
+        this.decryptPayload();
+      }
     }
 
     this.eventType   = this.parseEventType();
@@ -219,6 +223,45 @@ class Parser {
 
     const receivedPlaintext = decipher.update(ciphertext);
 
+    decipher.final();
+
+    this.buffer = Buffer.concat([
+      this.buffer.slice(0, this.eventOffset),
+      receivedPlaintext
+    ]);
+  }
+
+  decryptLegacyPayload() {
+    const msgLength   = this.buffer.length;
+    const eventLength = msgLength - this.eventOffset;
+
+    if (eventLength < 3) {
+      return;
+    }
+    if (this.bindKey == null) {
+      throw Error("Sensor data is encrypted. Please configure a bindKey.");
+    }
+
+    const encryptedPayload = this.buffer.slice(this.eventOffset, this.eventOffset + 6);
+
+    const nonce = Buffer.concat([
+      Buffer.from("01", "hex"),
+      this.buffer.slice(0, 5),
+      this.buffer.slice(-4, -1),
+      this.buffer.slice(5, 10), //mac_reversed
+      Buffer.from("0001", "hex"),
+    ]);
+
+    const bindKeyBuffer = Buffer.from(this.bindKey, "hex");
+    const key           = Buffer.concat([
+      bindKeyBuffer.slice(0, 6),
+      Buffer.from("8d3d3c97", "hex"),
+      bindKeyBuffer.slice(6)
+    ]);
+
+    const decipher = crypto.createCipheriv("aes-128-ctr", key, nonce);
+
+    const receivedPlaintext = decipher.update(encryptedPayload);
     decipher.final();
 
     this.buffer = Buffer.concat([


### PR DESCRIPTION
Encryption can be used for remotes and dimers. More details were analyzed in https://github.com/custom-components/ble_monitor/issues/289 
But it could not be done as in python, since crypto in node js supports only aes-ccm with auth tag for verifying the result. Many thanks to @Alx2000y for defeating this problem.

Decryption and parsing of messages was checked by me on the YLYK01YL remote control
beaconkey can be obtained using a python script:
```
wget https://raw.githubusercontent.com/custom-components/ble_monitor/master/custom_components/ble_monitor/ble_parser/get_beacon_key.py 
pip3 install bluepy

python3 get_beacon_key.py <MAC> <PRODUCT_ID>


#python3 get_beacon_key.py AB:CD:EF:12:34:56 959
```

It is suitable for the PRODUCT_ID list:

- 339: 'YLYK01YL'
- 950: 'YLKG07YL/YLKG08YL'
- 959: 'YLYB01YL-BHFRC'
- 1254: 'YLYK01YL-VENFAN'
- 1678: 'YLYK01YL-FANCL'
