### PR TITLE
whitelist known_device fixes

### DIFF
--- a/lib/devices.js
+++ b/lib/devices.js
@@ -57,10 +57,12 @@ exports.getByMac = function (mac) {
 }
 
 exports.getByName = function (name) {
+  let found;
   Object.keys(devices).forEach(function (k) {
     if (devices[k].name === name)
-      return devices[k];
+      found = devices[k];
   });
+  return found;
 }
 
 exports.deviceToAddr = function (id) {

--- a/lib/discovery.js
+++ b/lib/discovery.js
@@ -207,18 +207,17 @@ function checkIfBroken() {
 }
 
 // On some adapters you cannot scan and connect at same time, so if another process stops scanning, we restart to allow it priority.
-function block_exit(dur) {
-  let start = Date.now();
-  while ( true ) {
-    if ( Date.now() - start > dur ) process.exit(1);
-  }
-}
 var wasUs = false;
 var wasUsStop = false;
 exports.init = function () {
   noble.on("stateChange", onStateChange);
   noble.on("discover", onDiscovery);
   noble.on("scanStart", function () {
+    if ( !wasUs && !wishToScan ) {
+      // we are currently connected using EHub, but other process initates scan
+      // Whoever has connection open has priority. Stop the scan instantly
+      noble.stopScanning();
+    }
     isScanning    = true;
     scanStartTime = Date.now();
     log("Scanning started.");
@@ -250,12 +249,12 @@ exports.inRange = inRange;
 exports.restartScan = function () {
   wasUs = true;
   wishToScan = true;
-  if (!isScanning) {
-    log("Restarting scan");
-    noble.startScanning([], true);
-  } else {
-    log("restartScan: already scanning!");
+  //to be sure of scanning
+  scanStopCallback = function() {
+    noble.startScanning([],true);
   }
+  noble.stopScanning();
+  log("Restarting scan");
 }
 
 exports.stopScan = function (callback) {

--- a/lib/discovery.js
+++ b/lib/discovery.js
@@ -31,6 +31,7 @@ var packetsReceived     = 0;
 var lastPacketsReceived = 0;
 var scanStartTime       = Date.now();
 var isScanning          = false;
+var wishToScan          = false;
 var scanStopCallback    = null;
 
 function log(x) {
@@ -56,6 +57,8 @@ function onStateChange(state) {
   // delay startup to allow Bleno to set discovery up
   setTimeout(function () {
     log("Starting scan...");
+    wishToScan = true;
+    wasUs = true;
     noble.startScanning([], true);
   }, 1000);
 };
@@ -188,7 +191,9 @@ function checkForPresence() {
 }
 
 function checkIfBroken() {
-  if (isScanning) {
+  // Other processes can 'stopScanning' and 'startScanning'
+  // If this process intends to be Scanning, but is not, restart service.
+  if (wishToScan) {
     // If no packets for 10 seconds, restart
     if (packetsReceived == 0 && lastPacketsReceived == 0) {
       log("BLE broken? No advertising packets in " + config.ble_timeout + " seconds - restarting!");
@@ -201,6 +206,15 @@ function checkIfBroken() {
   packetsReceived     = 0;
 }
 
+// On some adapters you cannot scan and connect at same time, so if another process stops scanning, we restart to allow it priority.
+function block_exit(dur) {
+  let start = Date.now();
+  while ( true ) {
+    if ( Date.now() - start > dur ) process.exit(1);
+  }
+}
+var wasUs = false;
+var wasUsStop = false;
 exports.init = function () {
   noble.on("stateChange", onStateChange);
   noble.on("discover", onDiscovery);
@@ -208,14 +222,23 @@ exports.init = function () {
     isScanning    = true;
     scanStartTime = Date.now();
     log("Scanning started.");
+    wasUs = false;
   });
   noble.on("scanStop", function () {
     isScanning = false;
+    if ( !wasUsStop && wishToScan ) {
+      log("Scan has been requested to stop by other process using adapter, giving priority, so that it can make connection");
+      //stop scanning here then exit
+      exports.stopScan( () => {
+	process.exit(1);
+      });
+    }
     log("Scanning stopped.");
     if (scanStopCallback) {
       scanStopCallback();
       scanStopCallback = undefined;
     }
+    wasUsStop = false;
   });
   setInterval(checkForPresence, 1000);
   if (config.ble_timeout > 0)
@@ -225,6 +248,8 @@ exports.init = function () {
 exports.inRange = inRange;
 
 exports.restartScan = function () {
+  wasUs = true;
+  wishToScan = true;
   if (!isScanning) {
     log("Restarting scan");
     noble.startScanning([], true);
@@ -234,6 +259,8 @@ exports.restartScan = function () {
 }
 
 exports.stopScan = function (callback) {
+  wasUsStop = true;
+  wishToScan = false;
   if (isScanning) {
     scanStopCallback = callback;
     noble.stopScanning();

--- a/lib/mqttclient.js
+++ b/lib/mqttclient.js
@@ -97,7 +97,7 @@ client.on("message", function (topic, message) {
           var service = attributes.lookup(path[3].toLowerCase());
           var charc   = attributes.lookup(path[4].toLowerCase());
           connect.write(device, service, charc, convertMessage(message), function () {
-            client.publish(config.mqtt_prefix + "/written/" + id + "/" + path[3] + "/" + path[4], message);
+            client.publish(config.mqtt_prefix + "/written/" + path[2] + "/" + path[3] + "/" + path[4], message);
           });
         } else {
           log("Invalid number of topic levels");


### PR DESCRIPTION
1. When using known_devices in config.json the Name changing from the mac address makes some parts of the hub bridge break.
2. Some bluetooth adapters like the raspberry pi one, do not allow connect and scan at same time, so since E-Hub is scanning all of the time, it seems correct to make it step down when another application accesses the device.  Because usually before connecting other processes (eg. espruino-cli.js) will scan start then scan stop, its possible to detect in the noble callbacks if the start and stop was requested by your app or an outside app.  Just stopping the scan here when such a situation occurs allows the other program to connect, and then the current progam will be in a reboot cycle until the other program's connection ends, seems to work.