### PR TITLE
Continuation of fix for unusual noble adapter behavior.

### DIFF
--- a/lib/connect.js
+++ b/lib/connect.js
@@ -58,7 +58,7 @@ function Connection(device, callback) {
           jobInProgress = undefined;
         }
         if (!queue.length && !connections.length) // no open connections
-          discovery.restartScan();
+          discovery.startScan();
       });
       callback(null, connection);
     }
@@ -249,9 +249,8 @@ function getConnectedDevice(device, callback) {
     found.setUsed();
     callback(null, found);
   } else {
-    discovery.stopScan(function () {
-      new Connection(device, callback);
-    });
+    discovery.stopScan();
+    setTimeout(() => { new Connection(device,callback)},1000 );
   }
 }
 
@@ -261,15 +260,14 @@ function serviceQueue() {
     log("serviceQueue jobs " + queue.length);
   if (!queue.length) {
     if (connections.length == 0) // no open connections
-      discovery.restartScan();
+      discovery.startScan();
     return;
   }
   if (connections.length < config.max_connections) {
     var job = queue.shift();
-    discovery.stopScan(function () {
-      console.log("Starting job from Queue");
-      setTimeout(job, 100);
-    });
+    discovery.stopScan();
+    console.log("Starting job from Queue");
+    setTimeout(job, 100);
   }
 }
 

--- a/lib/discovery.js
+++ b/lib/discovery.js
@@ -28,11 +28,19 @@ const homeassistant = require("./homeassistant");
 // List of BLE devices that are currently in range
 var inRange             = {};
 var packetsReceived     = 0;
-var lastPacketsReceived = 0;
 var scanStartTime       = Date.now();
-var isScanning          = false;
-var wishToScan          = false;
-var scanStopCallback    = null;
+
+/*
+  On some adapters you cannot scan and connect at same time.
+  Tested on raspberry pi zero, the first startScan of an app, triggers both stop and start.
+  All external stops and starts are received as 'stop' callbacks for every app that is not its self.
+  This makes onStart reliable (for when it triggers itself), and onStop unreliable.
+  However we can't assume it works this way for all adapters, so try to rely on states as little as possible.
+  If Broken BLE restart tests seem best.
+*/
+var checkBrokenInterval = undefined;
+var wishToScan		= false;
+
 
 function log(x) {
   console.log("[Discover] " + x);
@@ -56,10 +64,7 @@ function onStateChange(state) {
   }
   // delay startup to allow Bleno to set discovery up
   setTimeout(function () {
-    log("Starting scan...");
-    wishToScan = true;
-    wasUs = true;
-    noble.startScanning([], true);
+    exports.startScan();
   }, 1000);
 };
 
@@ -178,7 +183,7 @@ async function onDiscovery(peripheral) {
 function checkForPresence() {
   var timeout = Date.now() - config.presence_timeout * 1000;
 
-  if (!isScanning || scanStartTime > timeout)
+  if (!wishToScan || scanStartTime > timeout)
     return; // don't check, as we're not scanning/haven't had time
 
   Object.keys(inRange).forEach(function (addr) {
@@ -191,79 +196,56 @@ function checkForPresence() {
 }
 
 function checkIfBroken() {
-  // Other processes can 'stopScanning' and 'startScanning'
-  // If this process intends to be Scanning, but is not, restart service.
-  if (wishToScan) {
-    // If no packets for 10 seconds, restart
-    if (packetsReceived == 0 && lastPacketsReceived == 0) {
-      log("BLE broken? No advertising packets in " + config.ble_timeout + " seconds - restarting!");
-      process.exit(1);
-    }
-  } else {
-    packetsReceived = 1; // don't restart as we were supposed to not be advertising
+  // If no packets for ble_timeout seconds, restart
+  log("Checking Broken!");
+  if (packetsReceived == 0) {
+    log("BLE broken? No advertising packets in " + config.ble_timeout + " seconds - restarting!");
+    process.exit(1);
   }
-  lastPacketsReceived = packetsReceived;
   packetsReceived     = 0;
 }
 
-// On some adapters you cannot scan and connect at same time, so if another process stops scanning, we restart to allow it priority.
-var wasUs = false;
-var wasUsStop = false;
+var scanOnCatch = false;
 exports.init = function () {
   noble.on("stateChange", onStateChange);
   noble.on("discover", onDiscovery);
   noble.on("scanStart", function () {
-    if ( !wasUs && !wishToScan ) {
-      // we are currently connected using EHub, but other process initates scan
-      // Whoever has connection open has priority. Stop the scan instantly
-      noble.stopScanning();
-    }
-    isScanning    = true;
     scanStartTime = Date.now();
     log("Scanning started.");
-    wasUs = false;
   });
   noble.on("scanStop", function () {
-    isScanning = false;
-    if ( !wasUsStop && wishToScan ) {
-      log("Scan has been requested to stop by other process using adapter, giving priority, so that it can make connection");
-      //stop scanning here then exit
-      exports.stopScan( () => {
-	process.exit(1);
-      });
+    //unreliable, because some adapters fire this when other processes start scanning
+    log("unreliable scanStop()");
+    if ( wishToScan ) {
+      // Scanning is lower priority, only way to allow others to connect, drop fast
+      process.exit(1);
     }
-    log("Scanning stopped.");
-    if (scanStopCallback) {
-      scanStopCallback();
-      scanStopCallback = undefined;
-    }
-    wasUsStop = false;
   });
   setInterval(checkForPresence, 1000);
-  if (config.ble_timeout > 0)
-    setInterval(checkIfBroken, config.ble_timeout * 1000);
 };
 
 exports.inRange = inRange;
 
-exports.restartScan = function () {
-  wasUs = true;
+exports.startScan = function () {
+  scanOnCatch = true;
+  log("caller if " + exports.startScan.caller);
   wishToScan = true;
-  //to be sure of scanning
-  scanStopCallback = function() {
-    noble.startScanning([],true);
+  if ( config.ble_timeout > 0 && checkBrokenInterval === undefined) {
+    log("Spawning check-broken interval");
+    checkBrokenInterval = setInterval(checkIfBroken, config.ble_timeout * 1000);
   }
-  noble.stopScanning();
-  log("Restarting scan");
+  // Other programs _could_ receive this signal as scanStopped
+  noble.startScanning([],true);
+  log("Starting Scan");
 }
 
-exports.stopScan = function (callback) {
-  wasUsStop = true;
+exports.stopScan = function () {
   wishToScan = false;
-  if (isScanning) {
-    scanStopCallback = callback;
-    noble.stopScanning();
-  } else if (callback) callback();
+  if (checkBrokenInterval) {
+    clearInterval(checkBrokenInterval);
+    checkBrokenInterval = undefined;
+  }
+  noble.stopScanning();
 }
 
 /// Send up to date presence data for all known devices over MQTT (to be done when first connected to MQTT)

--- a/lib/discovery.js
+++ b/lib/discovery.js
@@ -205,7 +205,6 @@ function checkIfBroken() {
   packetsReceived     = 0;
 }
 
-var scanOnCatch = false;
 exports.init = function () {
   noble.on("stateChange", onStateChange);
   noble.on("discover", onDiscovery);
@@ -216,6 +215,7 @@ exports.init = function () {
   noble.on("scanStop", function () {
     //unreliable, because some adapters fire this when other processes start scanning
     log("unreliable scanStop()");
+    // if this was us stopping scan, wishToScan would be false
     if ( wishToScan ) {
       // Scanning is lower priority, only way to allow others to connect, drop fast
       process.exit(1);
@@ -227,7 +227,6 @@ exports.init = function () {
 exports.inRange = inRange;
 
 exports.startScan = function () {
-  scanOnCatch = true;
   log("caller if " + exports.startScan.caller);
   wishToScan = true;
   if ( config.ble_timeout > 0 && checkBrokenInterval === undefined) {

--- a/lib/service.js
+++ b/lib/service.js
@@ -256,7 +256,7 @@ function onAccept(address) {
 
 function onDisconnect() {
   log("Disconnected");
-  discovery.restartScan();
+  discovery.startScan();
 }
 
 exports.init = function () {


### PR DESCRIPTION
I initially assumed that the signals were completely shared between programs in normal fashion. But turns out its a bit stranger than that.

- When a program does its first startScan, it does a stopScan and startScan underhood and is perceived by other progams as two stopScans.  When the progam calls startScan any further in future, this is perceived by other progams as one stopScan.
- Therefore stopScan is not very indicative of the current state, and shouldn't be relied upon.
- However, when a stopScan is called, it does indeed stop scanning for all programs.  If the stopScan was not triggered by us (use a boolean to guess with timing), then the stopScan means that another process is either starting a scan or stopping a scan, either way, they will want to use connect afterward, so dropping here allows that.

It sounds really complicated and strange thats because it is, but I think this setup is quite good, it allows another script to connect whilst the EHub service temporarily restarts. Has minimal side affects and should make using Ehub feel more smooth.  I will continue to test it over time, as I enjoy to use EHub when working with my Bangle.js