### PR TITLE
Implement BLE Energy sensor

### DIFF
--- a/lib/attributes.js
+++ b/lib/attributes.js
@@ -35,6 +35,7 @@ exports.names = {
   "2a6d": "Pressure",
   "2a6e": "Temperature",
   "2a6f": "Humidity",
+  "2af2": "Energy",
   // https://www.bluetooth.com/specifications/assigned-numbers/16-bit-uuids-for-members/
   "fe0f": "Philips",
   "fe95": "Xiaomi",
@@ -196,6 +197,11 @@ exports.handlers = {
   "2a58": function (a) { // org.bluetooth.characteristic.analog
     // probably not meant for advertising, but seems useful!
     return {analog: a[0] | (a.length > 1 ? (a[1] << 8) : 0)}
+  },
+  "2af2": function (a) { // Energy
+    return {
+      energy: a.readUInt32BE()
+    }
   },
   // org.bluetooth.characteristic.digital_output	0x2A57 ?
   "ffff": function (a) { // 0xffff isn't standard anything - just transmit it as 'data'

--- a/lib/homeassistant.js
+++ b/lib/homeassistant.js
@@ -33,6 +33,10 @@ const deviceTypes   = {
     unit_of_measurement: "%",
     device_class: "battery"
   },
+  energy: {
+    unit_of_measurement: "Wh",
+    device_class: "energy"
+  },
   illuminance: { // lx
     unit_of_measurement: "lx",
     device_class: "illuminance"


### PR DESCRIPTION
This PR implements the BLE energy-type sensor.

If used with the hardware setup on https://www.espruino.com/Smart+Meter it allows for automatic sensor discovery on home assistant