### PR TITLE
Advertise with device name, if configured

### DIFF
--- a/lib/discovery.js
+++ b/lib/discovery.js
@@ -166,8 +166,8 @@ async function onDiscovery(peripheral) {
 
         if (config.homeassistant) homeassistant.configDiscovery(decoded, dev, peripheral, d.uuid);
         for (var k in decoded) {
-          if (config.mqtt_advertise) mqtt.send(config.mqtt_prefix + "/advertise/" + id + "/" + k, JSON.stringify(decoded[k]));
-          if (config.mqtt_format_decoded_key_topic) mqtt.send(config.mqtt_prefix + "/" + k + "/" + id, JSON.stringify(decoded[k]));
+          if (config.mqtt_advertise) mqtt.send(config.mqtt_prefix + "/advertise/" + dev.name + "/" + k, JSON.stringify(decoded[k]));
+          if (config.mqtt_format_decoded_key_topic) mqtt.send(config.mqtt_prefix + "/" + k + "/" + dev.name, JSON.stringify(decoded[k]));
         }
 
         if (config.mqtt_format_json) {


### PR DESCRIPTION
The device name gets set to the MAC address, if no name is configured, so this should work for both cases.